### PR TITLE
fix: add_raster_layer tiles instead of url

### DIFF
--- a/anymap/anymap.py
+++ b/anymap/anymap.py
@@ -244,7 +244,7 @@ class MapLibreMap(MapWidget):
 
         # Add raster source
         self.add_source(
-            source_id, {"type": "raster", "url": source_url, "tileSize": 256}
+            source_id, {"type": "raster", "tiles": [source_url], "tileSize": 256}
         )
 
         # Add raster layer
@@ -472,7 +472,7 @@ class MapboxMap(MapWidget):
 
         # Add raster source
         self.add_source(
-            source_id, {"type": "raster", "url": source_url, "tileSize": 256}
+            source_id, {"type": "raster", "tiles": [source_url], "tileSize": 256}
         )
 
         # Add raster layer


### PR DESCRIPTION
This PR fixes an issue with `add_raster_layer`: should be using `tiles` parameter instead of `url`. This applies to Maplibre and Mapbox

`add_raster_layer` demo:

![anymap_raster_layer](https://github.com/user-attachments/assets/0ddfaf29-deeb-4062-b581-b58a570c4a8f)
