### PR TITLE
Add terra-draw control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ ENV/
 
 # IDE settings
 .vscode/
+GEMINI.md


### PR DESCRIPTION
```python
from anymap.maplibre import MapLibreMap

m = MapLibreMap(center=[42.76, -91.874], zoom=12)
m.add_terra_draw()
m

m.get_terra_draw_data()  # not working yet
m.clear_terra_draw_data() # working
```

```python
m = MapLibreMap(center=[42.76, -91.874], zoom=12)

m.add_terra_draw(
    position="top-left",
    modes=[            'point',
            'linestring',
            'polygon',
            'rectangle',
            'circle',
            'freehand',
            'angled-rectangle',
            'sensor',
            'sector',
            'select',
            'delete-selection',
            'delete',
            'download'],
    open=True
)
m
```

![image](https://github.com/user-attachments/assets/4bee15c4-5d33-4051-9dcf-ec74ff17936c)
