### PR TITLE
add flyTo options (kwargs) and fix maplibre lat/lon flyTo issue

### DIFF
--- a/anymap/base.py
+++ b/anymap/base.py
@@ -120,7 +120,9 @@ class MapWidget(anywidget.AnyWidget):
         """
         self.zoom = zoom
 
-    def fly_to(self, lat: float, lng: float, zoom: Optional[float] = None) -> None:
+    def fly_to(
+        self, lat: float, lng: float, zoom: Optional[float] = None, **kwargs
+    ) -> None:
         """Animate the map to fly to a specific location.
 
         Args:
@@ -128,7 +130,7 @@ class MapWidget(anywidget.AnyWidget):
             lng: Target longitude coordinate.
             zoom: Optional target zoom level. If None, keeps current zoom.
         """
-        options = {"center": [lat, lng]}
+        options = {"center": [lat, lng], **kwargs}
         if zoom is not None:
             options["zoom"] = zoom
         self.call_js_method("flyTo", options)

--- a/anymap/static/maplibre_widget.js
+++ b/anymap/static/maplibre_widget.js
@@ -1501,7 +1501,7 @@ function render({ model, el }) {
         switch (method) {
           case 'flyTo':
             const flyToOptions = args[0] || {};
-            // flyToOptions.center is already in [lng, lat] format
+            flyToOptions.center = [flyToOptions.center[1], flyToOptions.center[0]]; // [lat,lng] to [lng,lat]
             map.flyTo(flyToOptions);
             break;
 


### PR DESCRIPTION
- Expose kwargs in `fly_to`
- Fix Maplibre's flyTo: coordinates were inverted 

![fix-flyto_demo](https://github.com/user-attachments/assets/d14b5e50-af20-4f88-a3ac-1196ae9ca7e4)

A related note about the animation above:

In my case, I discovered I had "Animation effects" turned off in my PC, which means that the [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) is set as "reduce". 

[Mapbox respects](https://docs.mapbox.com/mapbox-gl-js/api/properties/#animationoptions) this and thus makes the "flyTo" animation behave as a "jumpTo" instead. However, you can still force the animation with the `essential` option set to true.  
