### PR TITLE
call initial js_calls issued before map loaded

### DIFF
--- a/anymap/static/mapbox_widget.js
+++ b/anymap/static/mapbox_widget.js
@@ -53,6 +53,16 @@ function render({ model, el }) {
 
   // Restore layers and sources from model state
   const restoreMapState = () => {
+
+    // Initial calls that were issued before map was loaded
+    const calls = model.get("_js_calls") || [];
+    calls.forEach(call => {
+      executeMapMethod(map, call, el);
+    });
+    // Clear the calls after processing
+    model.set("_js_calls", []);
+    model.save_changes();
+
     const layers = model.get("_layers") || {};
     const sources = model.get("_sources") || {};
 
@@ -101,6 +111,7 @@ function render({ model, el }) {
       // Restore state after map is fully loaded
       restoreMapState();
     }, 200);
+
   });
 
   // Additional resize handling for late-rendered widgets


### PR DESCRIPTION
I'm not so sure about this, but this PR makes sure that the _js_calls that were issued *before* the map was loaded, get called when the map loads. 


Example -- let's try to add one marker as soon as we build `m` and then display it. 

Currently, this first marker doesn't get added:

![mapbox_cell](https://github.com/user-attachments/assets/3fdc57da-84b6-4b21-a7a4-d9f98aa65a5c)

But it *does* get added to the map after we issue another command (e.g. adding a second marker as seen above)


Here's how it should behave (this PR):

![mapbox_cell_after](https://github.com/user-attachments/assets/ddfb6e90-b836-4e9a-8c5b-ac0c901a8568)



But.. I'm not sure if this is the correct order in `restoreMapState` -- I noticed other issues when displaying the map across multiple cells (also prior to this PR). Would you mind testing @giswqs ?
