### PR TITLE
Fix Potree Examples link

### DIFF
--- a/docs/examples/potree_example.ipynb
+++ b/docs/examples/potree_example.ipynb
@@ -511,7 +511,7 @@
     "\n",
     "### Sample Data Sources\n",
     "You can find sample Potree-compatible datasets at:\n",
-    "- [Potree Examples](http://potree.org/potree/examples/)\n",
+    "- [Potree Examples](https://potree.org/potree/examples/page.html)\n",
     "- [OpenTopography](https://www.opentopography.org/)\n",
     "- [3D BAG (Netherlands)](https://3dbag.nl/)\n",
     "\n",


### PR DESCRIPTION
Hi! 👋 

I was reading the [Potree-related documentation](https://anymap.dev/examples/potree_example/) and noticed I couldn't access the examples linked below (screenshot below). After checking the [respective repo](https://github.com/potree/potree.github.io/tree/master/potree/examples), I believe the correct URL is https://potree.org/potree/examples/page.html. This PR updates that link.

<img width="1297" height="235" alt="Forbidden: You don't have permission to access this resource. when accessing https://potree.org/potree/examples/" src="https://github.com/user-attachments/assets/11313569-f86f-4118-8c9b-2e865bb0953d" />

Thanks!