### PR TITLE
Pin maplibre-js version

### DIFF
--- a/anymap/compare.py
+++ b/anymap/compare.py
@@ -339,8 +339,8 @@ class MapCompare(anywidget.AnyWidget):
 
         # Choose CDN URLs based on backend
         if widget_state["backend"] == "maplibre":
-            map_js_url = "https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
-            map_css_url = "https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+            map_js_url = "https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.js"
+            map_css_url = "https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.css"
             global_var = "maplibregl"
         else:  # mapbox
             map_js_url = "https://api.mapbox.com/mapbox-gl-js/v3.13.0/mapbox-gl.js"

--- a/anymap/deckgl.py
+++ b/anymap/deckgl.py
@@ -258,8 +258,8 @@ class DeckGLMap(MapLibreMap):
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://unpkg.com/deck.gl@9.1.12/dist.min.js"></script>
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"></script>
-    <link href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css" rel="stylesheet">
+    <script src="https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.js"></script>
+    <link href="https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.css" rel="stylesheet">
     <style>
         body {{
             margin: 0;

--- a/anymap/static/deckgl_widget.js
+++ b/anymap/static/deckgl_widget.js
@@ -58,8 +58,8 @@ function render({ model, el }) {
   async function initializeDeckGL() {
     try {
       // Load MapLibre CSS and JS
-      await loadStylesheet('https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css');
-      await loadScript('https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js');
+      await loadStylesheet('https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.css');
+      await loadScript('https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.js');
 
       // Load DeckGL
       await loadScript('https://unpkg.com/deck.gl@9.1.12/dist.min.js');

--- a/anymap/static/maplibre_compare_widget.js
+++ b/anymap/static/maplibre_compare_widget.js
@@ -27,8 +27,8 @@ function loadCSS(href) {
 async function loadDependencies() {
     if (!window.maplibregl && !maplibreLoaded) {
         await Promise.all([
-            loadScript('https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js'),
-            loadCSS('https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css')
+            loadScript('https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.js'),
+            loadCSS('https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.css')
         ]);
         maplibreLoaded = true;
     }

--- a/anymap/static/maplibre_widget.js
+++ b/anymap/static/maplibre_widget.js
@@ -2866,7 +2866,7 @@ function render({ model, el }) {
       // Load MapLibre GL JS first
       if (!window.maplibregl) {
         const maplibreScript = document.createElement('script');
-        maplibreScript.src = 'https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js';
+        maplibreScript.src = 'https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.js';
 
         const previousDefine = window.define;
         const previousModule = window.module;
@@ -2956,7 +2956,7 @@ function render({ model, el }) {
       if (!document.querySelector('link[href*="maplibre-gl.css"]')) {
         const maplibreCSS = document.createElement('link');
         maplibreCSS.rel = 'stylesheet';
-        maplibreCSS.href = 'https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css';
+        maplibreCSS.href = 'https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.css';
         document.head.appendChild(maplibreCSS);
       }
 
@@ -3335,7 +3335,7 @@ function render({ model, el }) {
       if (!resolveGeoGridClass()) {
         try {
           // Load GeoGrid as ES module via dynamic import
-          const geoGridModule = await import('https://unpkg.com/geogrid-maplibre-gl@latest');
+          const geoGridModule = await import('https://unpkg.com/geogrid-maplibre-gl@5.10.0');
           window.GeoGrid = geoGridModule.GeoGrid || geoGridModule.default || geoGridModule;
 
           if (!resolveGeoGridClass()) {
@@ -3349,7 +3349,7 @@ function render({ model, el }) {
       if (!document.querySelector('link[href*="geogrid.css"]')) {
         const geogridCSS = document.createElement('link');
         geogridCSS.rel = 'stylesheet';
-        geogridCSS.href = 'https://unpkg.com/geogrid-maplibre-gl@latest/dist/geogrid.css';
+        geogridCSS.href = 'https://unpkg.com/geogrid-maplibre-gl@5.10.0/dist/geogrid.css';
         document.head.appendChild(geogridCSS);
 
       }


### PR DESCRIPTION
maplibre-js v5.11.0 has some issues with the geoman draw control. This PR pins maplibre-js to the working version v0.5.10.0